### PR TITLE
Change send transaction

### DIFF
--- a/docs/marina/api.md
+++ b/docs/marina/api.md
@@ -116,7 +116,7 @@ marina.getNextChangeAddress(): Promise<AddressInterface>
 ### sendTransaction
 
 ```typescript
-marina.sendTransaction(recipients: Recipient[], feeAssetHash?: string ): Promise<TransactionHash>
+marina.sendTransaction(recipients: Recipient[], feeAssetHash?: string ): Promise<TransactionID>
 ```
 
 `feeAssetHash` is an optional parameter. The default value is the network's L-BTC asset hash.

--- a/docs/marina/api.md
+++ b/docs/marina/api.md
@@ -8,7 +8,7 @@ image: /img/marina_logo.svg
 We recommend that all web developers read from the [Getting started](getting-started) section and onward .
 :::
 
-Marina injects a global API into websites visited by its users at window.marina. This API allows websites to request users' Liquid addresses and blinding keys, read data about the blockchain the user is connected to, and suggest that the user sign messages and send transactions. 
+Marina injects a global API into websites visited by its users at window.marina. This API allows websites to request users' Liquid addresses and blinding keys, read data about the blockchain the user is connected to, and suggest that the user sign messages and send transactions.
 
 The [marina-provider](https://www.npmjs.com/package/marina-provider) package provides a function `detectProvider` to inspect and fetch the `window.marina` provider.
 
@@ -116,10 +116,10 @@ marina.getNextChangeAddress(): Promise<AddressInterface>
 ### sendTransaction
 
 ```typescript
-marina.sendTransaction(recipients: Recipient[], feeAssetHash?: string ): Promise<TransactionHex>
+marina.sendTransaction(recipients: Recipient[], feeAssetHash?: string ): Promise<TransactionHash>
 ```
 
-`feeAssetHash` is an optional parameter. The default value is the network's L-BTC asset hash. 
+`feeAssetHash` is an optional parameter. The default value is the network's L-BTC asset hash.
 If another asset hash is specified, Marina will use Liquid Taxi to pay fees. [getFeeAssets](#getFeeAssets) lets to know the assets supported as `feeAssetHash`.
 
 ### blindTransaction
@@ -281,7 +281,7 @@ marina.on("NETWORK", (payload: string) => {
 The `detectProvider` function aims to fetch the providers injected by the browser extension.
 
 ```typescript
-const myProvider = await detectProvider<ProviderType>('providerName', 10000); 
+const myProvider = await detectProvider<ProviderType>('providerName', 10000);
 const marina = await detectProvider<MarinaProvider>('marina'); // default timeout = 3000
 ```
 > Under the hood, the function listens the `providerName#initialized` event emitted by the browser extension script.

--- a/docs/marina/balances.md
+++ b/docs/marina/balances.md
@@ -39,7 +39,7 @@ await window.marina.getNextChangeAddress();
 
 ## All addresses
 
-Retrieve all dervied confidential addresses with blidning keys till now
+Retrieve all derived confidential addresses with blinding keys till now
 ```js
 await window.marina.getAddresses();
 ```

--- a/docs/marina/balances.md
+++ b/docs/marina/balances.md
@@ -37,7 +37,7 @@ await window.marina.getNextChangeAddress();
 */
 ```
 
-## All addresses 
+## All addresses
 
 Retrieve all dervied confidential addresses with blidning keys till now
 ```js
@@ -65,10 +65,10 @@ const addrs = await window.marina.getAddresses();
 const utxos = await fetchAndUnblindUtxos(addrs, ESPLORA_API_URL);
 
 // It will return an array of unblinded utxos
-// we suggest to cache unblindData in order to speed-up 
+// we suggest to cache unblindData in order to speed-up
 // future transaction building and blinding.
 console.log(utxos);
-/* 
+/*
 [
   {
     txid: string;
@@ -78,7 +78,7 @@ console.log(utxos);
     prevout?: TxOutput;
     unblindData?: confidential.UnblindOutputResult;
   }
-] 
+]
 */
 ```
 

--- a/docs/marina/transaction.md
+++ b/docs/marina/transaction.md
@@ -11,9 +11,9 @@ You can delegate Marina to create, fund, blind, sign and broadcast a Liquid tran
 
 ```js
 // Send 0.007 LBTC to an address
-const rawTxHex = await window.marina.sendTransaction(
-  [ 
-    { 
+const txHash = await window.marina.sendTransaction(
+  [
+    {
       address: "el1qq2c6wq4qr32vgnd5zz9kc3a9n5ancmwak66zt35vvxa7hyemqw773mtlp8z0mmwm6y5tfcq53qv5y9rfq83kqfwwquxvepy6g", // the address of the recipient
       asset: "5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225", // the asset to send
       value: 700000 // amount always expressed in satoshis
@@ -21,13 +21,13 @@ const rawTxHex = await window.marina.sendTransaction(
   ],
 );
 
-console.log(rawTxHex); 
+console.log(txHash);
 ```
 
 This will prompt the user to allow blinding & signing a transaction.
 <img src="/img/marina_spend.png" alt="Marina Spend" width="300"/>
 
-If the prompt is accepted, will be possible to send the transaction
+If the prompt is accepted, the transaction will be blinded, signed and broadcasted.
 
 
 
@@ -43,7 +43,7 @@ import { Psbt, networks, BlindingDataLike } from 'liquidjs-lib';
 // Empty psbt elements
 const psbt = new liquid.Psbt({ network: networks.regtest });
 
-// Add inputs got from marina and outputs 
+// Add inputs got from marina and outputs
 psbt.addInput({
   //...
 });
@@ -66,7 +66,7 @@ await psbt.blindOutputs(
 
 // encode to base64
 const encodedTx = psbt.toBase64();
-        
+
 // now you can sign with Marina
 const signedTx = await window.marina.signTransaction(encodedTx);
 ```

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -146,7 +146,7 @@ const MarinaExample: React.FC<Props> = () => {
               txHash.length > 0 &&
               <>
                 <p>
-                  {txHash.substring(0, 20) + "..." + txHash.substring((txHash.length - 20), txHash.length)}
+                  {txHash}
                 </p>
                 <button
                   onClick={() => copy(txHash)}

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -20,7 +20,6 @@ const MarinaExample: React.FC<Props> = () => {
   const [connected, setConnected] = useState(false);
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState(0);
-  const [tx, setTx] = useState('');
   const [network, setNetwork] = useState<'liquid' | 'regtest'>('liquid');
   const [error, setError] = useState('');
   const [txHash, setTxHash] = useState('');
@@ -61,14 +60,14 @@ const MarinaExample: React.FC<Props> = () => {
 
   const send = async () => {
     try {
-      const rawtx = await marina.sendTransaction([{
+      const txHash = await marina.sendTransaction([{
         address: recipient,
         value: amount,
         asset: L_BTC[network]
       }]);
-      
-      console.log(rawtx);
-      setTx(rawtx);
+
+      console.log(txHash);
+      setTxHash(txHash);
 
     } catch (e) {
       console.error(e);
@@ -144,13 +143,13 @@ const MarinaExample: React.FC<Props> = () => {
               Send LBTC
             </button>
             {
-              tx.length > 0 &&
+              txHash.length > 0 &&
               <>
                 <p>
-                  {tx.substring(0, 20) + "..." + tx.substring((tx.length - 20), tx.length)}
+                  {txHash.substring(0, 20) + "..." + txHash.substring((txHash.length - 20), txHash.length)}
                 </p>
                 <button
-                  onClick={() => copy(tx)}
+                  onClick={() => copy(txHash)}
                   style={{
                     height: '50px',
                     width: '350px'


### PR DESCRIPTION
Related with https://github.com/vulpemventures/marina/pull/289

Previously `sendTransaction` returned the raw signed transaction.
Now blinds, sign and broadcast the transaction, and returns the transaction hash (id).

@tiero please review